### PR TITLE
Apply shellcheck fixes

### DIFF
--- a/modify_reference_path.sh
+++ b/modify_reference_path.sh
@@ -3,10 +3,10 @@
 refpath_default=$1
 refpath_modified=$2
 
-cat ${refpath_default} | \
+cat "${refpath_default}" | \
     sed 's|IMPUTEINFOFILE = \".*|IMPUTEINFOFILE = \"/opt/battenberg_reference/impute_info.txt\"|' | \
     sed 's|G1000PREFIX = \".*|G1000PREFIX = \"/opt/battenberg_reference/1000_genomes_loci/1000_genomes_allele_index_chr\"|' | \
     sed 's|G1000PREFIX_AC = \".*|G1000PREFIX_AC = \"/opt/battenberg_reference/1000_genomes_loci/1000_genomes_loci_chr\"|' | \
     sed 's|GCCORRECTPREFIX = \".*|GCCORRECTPREFIX = \"/opt/battenberg_reference/1000_genomes_gcContent/1000_genomes_GC_corr_chr\"|' | \
     sed 's|PROBLEMLOCI = \".*|PROBLEMLOCI = \"/opt/battenberg_reference/battenberg_problem_loci/probloci.txt.gz\"|' | \
-    sed 's|REPLICCORRECTPREFIX = \".*|REPLICCORRECTPREFIX = \"/opt/battenberg_reference/battenberg_wgs_replication_timing_correction_1000_genomes/1000_genomes_replication_timing_chr\"|' > ${refpath_modified}
+    sed 's|REPLICCORRECTPREFIX = \".*|REPLICCORRECTPREFIX = \"/opt/battenberg_reference/battenberg_wgs_replication_timing_correction_1000_genomes/1000_genomes_replication_timing_chr\"|' > "${refpath_modified}"


### PR DESCRIPTION
[Shellcheck](https://github.com/koalaman/shellcheck) is a tool for finding problematic code in shell scripts, from syntax errors to subtle and non-intuitive [pitfalls](https://mywiki.wooledge.org/BashPitfalls). It is also capable of automatically fixed some kinds of issues.

Eventually shellcheck will be enabled in the CI/CD checks (i.e. the linters) used by this repository. In order to ease that transition (and make your life easier!), this PR includes all code fixes that could be performed automatically.

**None of these fixes have been tested** - this pull request was generated by a script and should be reviewed _very closely_.

These changes make the shell scripts in this repository abide by the following shellcheck rules:
* [Double quote to prevent globbing and word splitting.](https://www.shellcheck.net/wiki/SC2086)

There were also warnings that could not be fixed automatically:

```console

In modify_reference_path.sh line 6:
cat "${refpath_default}" | \
    ^------------------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.

For more information:
  https://www.shellcheck.net/wiki/SC2002 -- Useless cat. Consider 'cmd < file...
```


If any of these fixes/warnings are incorrect, shellcheck can be silenced by adding a line like `#shellcheck disable=<rule name>` immediately before the offending line ([docs](https://github.com/koalaman/shellcheck/wiki/Ignore#ignoring-one-specific-instance-in-a-file)).

Also, you _can_ just sidestep this issue completely by adding a `.cicd-env` file to the root of this repository with `VALIDATE_SHELL="false"` ([reference](https://github.com/uclahs-cds/docker-CICD-base#configuration)). Please only do that as a last resort - [linters are on your side](https://stackoverflow.blog/2020/07/20/linters-arent-in-your-way-theyre-on-your-side/)!