### PR TITLE
Use `pkgdepends`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+### Chanded
+- Use the official `r-base:4.4.1` docker image
+- Replace GitHub package installation with `pkgdepends`
+
+### Added
+- Add installer.R that uses `pkgdepends`
+
+---
 
 ## [2.2.9] - 2023-06-27
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG BATTENBERG="Wedge-lab/battenberg@v${BATTENBERG_VERSION}"
 ARG LIBRARY="/usr/lib/R/site-library"
 
 # Install Package Dependency toolkit
-RUN library=${LIBRARY} R -e 'install.packages(c("argparse", "BiocManager", "pkgdepends", "optparse"), lib = Sys.getenv("library"))' &&\
+RUN library=${LIBRARY} R -e 'install.packages(c("argparse", "BiocManager", "pkgdepends", "optparse"), lib = Sys.getenv("library"))' && \
     R -q -e 'BiocManager::install(c("ellipsis", "splines", "VariantAnnotation"))'
 
 # Install Battenberg

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update \
         libpng-dev \
         libssl-dev \
         libxml2-dev \
-        python3
+        python3 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Main tool version
 ARG BATTENBERG_VERSION="2.2.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN Rscript /usr/local/bin/installer.R -l ${LIBRARY} -d ${COPYNUMBER} ${ASCAT} $
 # Modify paths to reference files
 COPY modify_reference_path.sh /usr/local/bin/modify_reference_path.sh
 RUN chmod +x /usr/local/bin/modify_reference_path.sh && \
-    bash /usr/local/bin/modify_reference_path.sh /usr/local/lib/R/site-library/Battenberg/example/battenberg_wgs.R /usr/local/bin/battenberg_wgs.R
+    bash /usr/local/bin/modify_reference_path.sh /usr/lib/R/site-library/Battenberg/example/battenberg_wgs.R /usr/local/bin/battenberg_wgs.R
 
 RUN ln -sf /usr/local/lib/R/site-library/Battenberg/example/filter_sv_brass.R /usr/local/bin/filter_sv_brass.R && \
     ln -sf /usr/local/lib/R/site-library/Battenberg/example/battenberg_cleanup.sh /usr/local/bin/battenberg_cleanup.sh

--- a/installer.R
+++ b/installer.R
@@ -1,0 +1,42 @@
+library(argparse);
+library(pkgdepends);
+
+parser <- ArgumentParser();
+
+parser$add_argument(
+    '-r',
+    '--repo-name',
+    help = 'Specify the repo name'
+    );
+parser$add_argument(
+    '-av',
+    '--add-version',
+    help = 'Specify tool version'
+    );
+
+args <- parser$parse_args();
+
+repo <- args$repo_name;
+version <- args$add_version;
+
+if (!(startsWith(version, 'v'))) {
+    version <- paste('v', version, sep = '')
+    };
+
+tool <- paste(repo, '@' ,version, sep = '');
+
+pkg.download.proposal <- new_pkg_download_proposal(tool);
+pkg.download.proposal$resolve();
+pkg.download.proposal$download();
+
+#Packages and dependencies will be installed in the path below
+lib <- '/usr/lib/R/site-library';
+config <- list(library = lib);
+
+pkg.installation.proposal <- new_pkg_installation_proposal(
+  tool,
+  config = list(library = lib)
+);
+pkg.installation.proposal$solve();
+pkg.installation.proposal$download();
+pkg.installation.proposal$install();

--- a/installer.R
+++ b/installer.R
@@ -4,39 +4,26 @@ library(pkgdepends);
 parser <- ArgumentParser();
 
 parser$add_argument(
-    '-r',
-    '--repo-name',
-    help = 'Specify the repo name'
+    '-l',
+    '--lib',
+    help = 'Library path to install the tools'
     );
 parser$add_argument(
-    '-av',
-    '--add-version',
-    help = 'Specify tool version'
+    '-d',
+    '--dependencies',
+    nargs = '+',
+    help = 'List dependencies separated by space'
     );
 
 args <- parser$parse_args();
 
-repo <- args$repo_name;
-version <- args$add_version;
-
-if (!(startsWith(version, 'v'))) {
-    version <- paste('v', version, sep = '')
-    };
-
-tool <- paste(repo, '@' ,version, sep = '');
-
-pkg.download.proposal <- new_pkg_download_proposal(tool);
-pkg.download.proposal$resolve();
-pkg.download.proposal$download();
-
-#Packages and dependencies will be installed in the path below
-lib <- '/usr/lib/R/site-library';
-config <- list(library = lib);
+tools <- args$dependencies;
+lib <- args$lib;
 
 pkg.installation.proposal <- new_pkg_installation_proposal(
-  tool,
-  config = list(library = lib)
-);
+    tools,
+    config = list(library = lib)
+    );
 pkg.installation.proposal$solve();
 pkg.installation.proposal$download();
 pkg.installation.proposal$install();


### PR DESCRIPTION
# Description
This PR adds `pkgdepends` to install Battenberg and other dependencies.

### Closes #...

## Testing Results

### Docker Image Testing

- [x] I have tested the Docker image with the `docker run` command as described below.

#### Test the Docker image with at least one sample. Verify the new Docker image works using:

```docker run -u $(id -u):$(id -g) –w <working-directory> -v <directory-you-want-to-mount>:<how-you-want-to-mount-it-within-the-docker> --rm <docker-image-name> <command-to-the-docker-with-all-parameters>```

#### My command: 

```docker run --rm -u $(id -u):$(id -g) battenberg:2.2.9 Rscript /usr/local/bin/battenberg_wgs.R -h```

```
[mmootor@ip-0A125937 docker-Battenberg]$ docker run --rm -u $(id -u):$(id -g) bb:2.2.9 Rs
cript /usr/local/bin/battenberg_wgs.R -h
Usage: /usr/local/bin/battenberg_wgs.R [options]


Options:
        -t CHARACTER, --tumourname=CHARACTER
                Samplename of the tumour

        -n CHARACTER, --normalname=CHARACTER
                Samplename of the normal

        --tb=CHARACTER
                Tumour BAM file

        --nb=CHARACTER
                Normal BAM file

        --sex=CHARACTER
                Sex of the sample

        -o CHARACTER, --output=CHARACTER
                Directory where output will be written

        --skip_allelecount
                Provide when alleles don't have to be counted. This expects allelecount files on disk

        --skip_preprocessing
                Provide when pre-processing has previously completed. This expects the files on disk

        --skip_phasing
                Provide when phasing has previously completed. This expects the files on disk

        --cpu=CHARACTER
                The number of CPU cores to be used by the pipeline (Default: 8)

        --bp=CHARACTER
                Optional two column file (chromosome and position) specifying prior breakpoints to be used during segmentation

        -h, --help
                Show this help message and exit
```

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### Formatting

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

### File Updates

- [x] I have ensured that the version number update follows the [versioning standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3188472/Docker+image+versioning+standardization).

- [x] I have updated the version number in the `Dockerfile`, `README.md` and `metadata.yaml` files.

- [x] I have updated the dependencies and added my name to the maintainer list in the `Dockerfile`.

- [ ] I have updated the feature changes in the `README.md` (optional).

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### GitHub Packages Auto Build Rules

- [x] I have not manually pushed this Docker image to the uclahs-cds container registry (`ghcr.io/uclahs-cds`) on [GitHub](https://github.com/orgs/uclahs-cds/packages).

- [x] **I have updated the `image_name`** in the `metadata.yaml` which is required by GitHub action to automatically build and push the image.
